### PR TITLE
Fix translation domains

### DIFF
--- a/src/appmenu.ui
+++ b/src/appmenu.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<interface domain="draw">
+<interface domain="dynamic-wallpaper-editor">
   <menu id="app-menu">
     <section id="new">
       <item>

--- a/src/dynamic-wallpaper-editor.in
+++ b/src/dynamic-wallpaper-editor.in
@@ -21,6 +21,7 @@ import os
 import sys
 import signal
 import gettext
+import locale
 
 VERSION = '@VERSION@'
 pkgdatadir = '@pkgdatadir@'
@@ -29,6 +30,7 @@ localedir = '@localedir@'
 sys.path.insert(1, pkgdatadir)
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 gettext.install('dynamic-wallpaper-editor', localedir)
+locale.bindtextdomain('dynamic-wallpaper-editor', localedir)
 
 if __name__ == '__main__':
     import gi

--- a/src/window.ui
+++ b/src/window.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<interface>
+<interface domain="dynamic-wallpaper-editor">
 	<template class="DynamicWallpaperEditorWindow" parent="GtkApplicationWindow">
 		<property name="default-width">900</property>
 		<property name="default-height">500</property>


### PR DESCRIPTION
* Fix translation domains in `.ui` files
* Bind text domain to `dynamic-wallpaper-editor` for Gtk3